### PR TITLE
POM changes to fix build forking

### DIFF
--- a/opensocial-explorer-webcontent/pom.xml
+++ b/opensocial-explorer-webcontent/pom.xml
@@ -88,8 +88,10 @@
       </resource>
     </resources>
     <plugins>
-      <plugin>
-         <!-- Documentation: http://jslint4java.googlecode.com/svn/docs/2.0.0/maven.html -->
+      <!-- Documentation: http://jslint4java.googlecode.com/svn/docs/2.0.0/maven.html -->
+      <!-- I don't think we need this plugin right now since the plugin in the reporting section
+           does the same thing.  Keeping this here until we make the final decision -->
+      <!-- <plugin>
         <groupId>com.googlecode.jslint4java</groupId>
         <artifactId>jslint4java-maven-plugin</artifactId>
         <version>2.0.0</version>
@@ -113,7 +115,7 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
+      </plugin> -->
       <plugin>
         <!-- Documentation: http://searls.github.com/jasmine-maven-plugin/ -->
         <groupId>com.github.searls</groupId>
@@ -156,9 +158,10 @@
         <artifactId>maven-jstools-plugin</artifactId>
         <version>${maven-jstools-plugin.version}</version>
         <configuration>
-          <jsDir>src/main/javascript</jsDir>
+          <jsDir>${basedir}/src/main/javascript</jsDir>
           <includePrivate>true</includePrivate>
           <includeUndocumented>true</includeUndocumented>
+          <includes>**/*.js</includes>  
         </configuration>
         <reportSets>
           <reportSet>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
     <scmpublish.content>target/staging</scmpublish.content>
     <doxia-module-markdown.version>1.3</doxia-module-markdown.version>
     <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
-    <maven-javadoc-plugin.version>2.9</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>1.4</maven-gpg-plugin.version>
     <maven-release-plugin.version>2.4.1</maven-release-plugin.version>
   </properties>
@@ -205,115 +204,7 @@
             </dependency>
           </dependencies>
           <configuration>
-            <reportPlugins>
-              <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${maven-project-info-reports-plugin.version}</version>
-                <reports>
-                  <report>index</report>
-                  <report>project-team</report>
-                  <report>license</report>
-                  <report>mailing-list</report>
-                  <!-- Some of these reports are hanging the builds trying 
-                    to pull down dependency information -->
-                  <!-- <report>dependencies</report> -->
-                  <report>dependency-convergence</report>
-                  <report>plugin-management</report>
-                  <report>cim</report>
-                  <report>issue-tracking</report>
-                  <report>scm</report>
-                  <report>summary</report>
-                </reports>
-              </plugin>
-              <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${findbugs.version}</version>
-                <configuration>
-                  <xmlOutput>true</xmlOutput>
-                  <xmlOutputDirectory>target/site</xmlOutputDirectory>
-                  <effort>Max</effort>
-                  <threshold>Low</threshold>
-                </configuration>
-              </plugin>
-              <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>${cobertura.version}</version>
-                <configuration>
-                  <formats>
-                    <format>xml</format>
-                    <format>html</format>
-                  </formats>
-                </configuration>
-              </plugin>
-              <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>${maven-surefire-report-plugin.version}</version>
-              </plugin>
-              <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
-              </plugin>
-              <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>jdepend-maven-plugin</artifactId>
-                <version>${jdepend-maven-plugin.version}</version>
-              </plugin>
-              <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>taglist-maven-plugin</artifactId>
-                <version>${taglist-maven-plugin.version}</version>
-                <configuration>
-                  <tagListOptions>
-                    <tagClasses>
-                      <tagClass>
-                        <displayName>Code Work</displayName>
-                        <tags>
-                          <tag>
-                            <matchString>TODO</matchString>
-                            <matchType>ignoreCase</matchType>
-                          </tag>
-                        </tags>
-                      </tagClass>
-                      <tagClass>
-                        <displayName>Bugs</displayName>
-                        <tags>
-                          <tag>
-                            <matchString>FIXME</matchString>
-                            <matchType>ignoreCase</matchType>
-                          </tag>
-                        </tags>
-                      </tagClass>
-                    </tagClasses>
-                  </tagListOptions>
-                </configuration>
-              </plugin>
-              <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <version>${apache-rat-plugin.version}</version>
-                <configuration>
-                  <excludeSubProjects>false</excludeSubProjects>
-                  <excludes>
-                    <exclude>**/MANIFEST.MF</exclude>
-                    <exclude>**/target/**</exclude>
-                    <exclude>**/*.classpath</exclude>
-                    <exclude>**/.project</exclude>
-                    <exclude>**/.settings/*</exclude>
-                    <exclude>**/src/test/resources/**</exclude>
-                    <exclude>**/resources/libs/codemirror/**</exclude>
-                    <exclude>**/resources/libs/bootstrap/**</exclude>
-                    <exclude>**/*.json</exclude>
-                    <exclude>**/src/main/specs/specs.txt</exclude>
-                    <exclude>**/src/main/resources/js/modules/templates/**</exclude>
-                  </excludes>
-                </configuration>
-              </plugin>
-            </reportPlugins>
+            
           </configuration>
         </plugin>
         <plugin>
@@ -349,6 +240,131 @@
   <!-- ====================================================================== -->
   <reporting>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>${maven-project-info-reports-plugin.version}</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>index</report>
+              <report>project-team</report>
+              <report>license</report>
+              <report>mailing-list</report>
+              <!-- Some of these reports are hanging the builds trying 
+                to pull down dependency information -->
+              <!-- <report>dependencies</report> -->
+              <report>dependency-convergence</report>
+              <report>plugin-management</report>
+              <report>cim</report>
+              <report>issue-tracking</report>
+              <report>scm</report>
+              <report>summary</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>${findbugs.version}</version>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <xmlOutputDirectory>target/site</xmlOutputDirectory>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>${cobertura.version}</version>
+        <configuration>
+          <formats>
+            <format>xml</format>
+            <format>html</format>
+          </formats>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-report-plugin</artifactId>
+        <version>${maven-surefire-report-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jdepend-maven-plugin</artifactId>
+        <version>${jdepend-maven-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <version>${taglist-maven-plugin.version}</version>
+        <configuration>
+          <tagListOptions>
+            <tagClasses>
+              <tagClass>
+                <displayName>Code Work</displayName>
+                <tags>
+                  <tag>
+                    <matchString>TODO</matchString>
+                    <matchType>ignoreCase</matchType>
+                  </tag>
+                </tags>
+              </tagClass>
+              <tagClass>
+                <displayName>Bugs</displayName>
+                <tags>
+                  <tag>
+                    <matchString>FIXME</matchString>
+                    <matchType>ignoreCase</matchType>
+                  </tag>
+                </tags>
+              </tagClass>
+            </tagClasses>
+          </tagListOptions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <version>${apache-rat-plugin.version}</version>
+        <configuration>
+          <excludeSubProjects>false</excludeSubProjects>
+          <excludes>
+            <exclude>**/MANIFEST.MF</exclude>
+            <exclude>**/target/**</exclude>
+            <exclude>**/*.classpath</exclude>
+            <exclude>**/.project</exclude>
+            <exclude>**/.settings/*</exclude>
+            <exclude>**/src/test/resources/**</exclude>
+            <exclude>**/resources/libs/codemirror/**</exclude>
+            <exclude>**/resources/libs/bootstrap/**</exclude>
+            <exclude>**/*.json</exclude>
+            <exclude>**/src/main/specs/specs.txt</exclude>
+            <exclude>**/src/main/resources/js/modules/templates/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${maven-javadoc-plugin.version}</version>
+        <reportSets>
+          <reportSet>
+            <!-- 
+                 select non-aggregate reports, aggregate reports cause the build
+                 to fork and build the sub-modules which in some cases can result
+                 in build errors if certain artifacts are not installed in the 
+                 local maven repo
+            -->
+            <reports>
+              <report>javadoc</report>
+              <report>test-javadoc</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
     </plugins>
   </reporting>
 
@@ -391,9 +407,9 @@
               <execution>
                 <id>attach-javadocs</id>
                 <goals>
-                  <goal>jar</goal>
-                  <goal>test-jar</goal>
+                  <goal>aggregate</goal>
                 </goals>
+                <phase>site</phase>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
The problem was the maven-javadoc-plugin was causing the build to fork when executing the site goal.  Since the site goal was executed on every module before all the install goal on each module was run we ended up failing because dependencies could not be resolved or we succeeded but used existing dependencies in the maven repo.  The key change here was to use non-aggregate reports when running the javadoc-plugin.
