### PR TITLE
Fixing javadoc plugin used during release to generate javadoc jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,9 +407,9 @@
               <execution>
                 <id>attach-javadocs</id>
                 <goals>
-                  <goal>aggregate</goal>
+                  <goal>jar</goal>
+                  <goal>test-jar</goal>
                 </goals>
-                <phase>site</phase>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
I think something happened when I made changes to fix the forking problem where I accidentally changed the execution of the javadoc plugin during the release.  I confirmed that this change does not cause the build to fork during the site goal.
