### PR TITLE
Upgrading to Shindig 2.5.0 from Shindig 2.5.0-beta6.

### DIFF
--- a/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/gadgetarea/GadgetArea.js
+++ b/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/gadgetarea/GadgetArea.js
@@ -267,16 +267,11 @@ define(['dojo/_base/declare', 'dijit/_WidgetBase', 'dijit/_TemplatedMixin',
                   this.containerToken = token;
                   this.containerTokenTTL = ttl;
                   shindig.auth.updateSecurityToken(token);
-                  // FIXME: Workaround for a bug in 2.5.0 beta6 of Shindig - fixed in Shindig 2.5.0
+                  // FIXME: Fixed by https://issues.apache.org/jira/browse/SHINDIG-1924
                   // Begin GROSS
-                  this.container.sites = this.container.sites_;
-                  // End GROSS
-                  
-                  // FIXME: My fix in Shindig 2.5.0 wasn't sufficient. Fixed in Shindig 2.5.1
-                  // Begin more GROSS
                   sites = sites_ = this.container.sites_;
                   commonContainer = this.container;
-                  // End more GROSS
+                  // End GROSS
                   dojo.hitch(this.container, 'forceRefreshAllTokens')();
                 },
                 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
   <!-- ====================================================================== -->
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <shindig.version>2.5.0-beta6</shindig.version>
+    <shindig.version>2.5.0</shindig.version>
     <pom.version>2.0.0</pom.version>
     <maven-eclipse-plugin.version>2.9</maven-eclipse-plugin.version>
     <maven-site-plugin.version>3.2</maven-site-plugin.version>


### PR DESCRIPTION
 Removing Shindig 2.5.0-beta6 specific workarounds.
