### PR TITLE
Remove license headers in gadgets and associated resources

### DIFF
--- a/gadget-specs/src/main/specs/actions/actions-by-path/gadget.xml
+++ b/gadget-specs/src/main/specs/actions/actions-by-path/gadget.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <Module>
   <ModulePrefs title="Actions by Path">
     <Require feature="dynamic-height"></Require>

--- a/gadget-specs/src/main/specs/actions/actions-by-type/gadget.xml
+++ b/gadget-specs/src/main/specs/actions/actions-by-type/gadget.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <Module>
   <ModulePrefs title="Actions by Type">
     <Require feature="dynamic-height"></Require>

--- a/gadget-specs/src/main/specs/actions/actions-with-views/gadget.xml
+++ b/gadget-specs/src/main/specs/actions/actions-with-views/gadget.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <Module>
   <ModulePrefs title="Actions with Views">
     <Require feature="dynamic-height"></Require>

--- a/gadget-specs/src/main/specs/embedded-experiences/YouTube/YouTubePlayer.xml
+++ b/gadget-specs/src/main/specs/embedded-experiences/YouTube/YouTubePlayer.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <Module>
 	<ModulePrefs title="YouTube Player" description="YouTube Player Using Embedded Experiences" height="400" width="700">
 		<Require feature="embedded-experiences"></Require>

--- a/gadget-specs/src/main/specs/makeRequest/gadget.xml
+++ b/gadget-specs/src/main/specs/makeRequest/gadget.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <Module>
   <ModulePrefs title="Make Request Example">
     <Require feature="dynamic-height"></Require>

--- a/gadget-specs/src/main/specs/makeRequest/makeRequest.js
+++ b/gadget-specs/src/main/specs/makeRequest/makeRequest.js
@@ -1,21 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 function lookupTeam() {
   var index = document.getElementById('team').selectedIndex;
   var options = document.getElementById('team').options;

--- a/gadget-specs/src/main/specs/oauth/oauth10a/YouTube/YouTube.xml
+++ b/gadget-specs/src/main/specs/oauth/oauth10a/YouTube/YouTube.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <Module>
   <ModulePrefs title="YouTube Gadget" width="700" scrolling="true">
     <Require feature="dynamic-height" />

--- a/gadget-specs/src/main/specs/oauth/oauth2/google/gadget.xml
+++ b/gadget-specs/src/main/specs/oauth/oauth2/google/gadget.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <Module>
   <ModulePrefs title="Demo OAuth2 Authorization Code Gadget (Simple pull from Google Contacts)">
     <OAuth2>

--- a/gadget-specs/src/main/specs/open-views/all-features/gadget.xml
+++ b/gadget-specs/src/main/specs/open-views/all-features/gadget.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <Module>
   <ModulePrefs title="Open Views Demo">
     <Require feature="dynamic-height"></Require>

--- a/gadget-specs/src/main/specs/open-views/all-features/open-views.html
+++ b/gadget-specs/src/main/specs/open-views/all-features/open-views.html
@@ -1,21 +1,3 @@
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <html>
   <head>
     <script type="text/javascript" src="open-views.js"></script>

--- a/gadget-specs/src/main/specs/open-views/all-features/open-views.js
+++ b/gadget-specs/src/main/specs/open-views/all-features/open-views.js
@@ -1,21 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 var currentSite;
 function initButtons() {
   document.getElementById('open').onclick = open;

--- a/gadget-specs/src/main/specs/preferences/gadget.xml
+++ b/gadget-specs/src/main/specs/preferences/gadget.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <Module>
   <ModulePrefs title="Preferences Gadget" description="Tests setting and getting user preferences." width="320" height="400">
   <Require feature="setprefs"/>

--- a/gadget-specs/src/main/specs/selection/selection-listener/gadget.xml
+++ b/gadget-specs/src/main/specs/selection/selection-listener/gadget.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <Module>
   <ModulePrefs title="Selection Listener">
     <Require feature="dynamic-height"></Require>

--- a/gadget-specs/src/main/specs/welcome/gadget.xml
+++ b/gadget-specs/src/main/specs/welcome/gadget.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <Module>
   <ModulePrefs title="Welcome Gadget" description="Welcome people to the OpenSocial Explorer">
     <Require feature="minimessage" />

--- a/gadget-specs/src/main/specs/welcome/welcome.css
+++ b/gadget-specs/src/main/specs/welcome/welcome.css
@@ -1,21 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 .mmlib_table {
   width: 100%;
   font: bold 9px arial,sans-serif;

--- a/gadget-specs/src/main/specs/welcome/welcome.html
+++ b/gadget-specs/src/main/specs/welcome/welcome.html
@@ -1,21 +1,3 @@
-<!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
--->
 <html>
   <head>
     <link type="text/css" rel="stylesheet" href="welcome.css"/>

--- a/gadget-specs/src/main/specs/welcome/welcome.js
+++ b/gadget-specs/src/main/specs/welcome/welcome.js
@@ -1,21 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 function welcome() {
   var miniMessage = new gadgets.MiniMessage();
   miniMessage.createStaticMessage("Welcome to the OpenSocial Explorer!");

--- a/opensocial-explorer-webcontent/src/main/resources/explore.html
+++ b/opensocial-explorer-webcontent/src/main/resources/explore.html
@@ -94,7 +94,8 @@
       <hr>
 
       <footer>
-        <p>&copy; OpenSocial Foundation 2013</p>
+        <p>&copy; OpenSocial Foundation 2013.  All sample gadgets, including any associated HTML, JavaScript, CSS, and JSON, 
+        are covered under the <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache V2 License</a>.</p>
       </footer>
 
     </div><!--/.fluid-container-->

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,10 @@
             <exclude>**/resources/libs/bootstrap/**</exclude>
             <exclude>**/*.json</exclude>
             <exclude>**/src/main/specs/specs.txt</exclude>
+            <exclude>**/src/main/specs/**/*.xml</exclude>
+            <exclude>**/src/main/specs/**/*.html</exclude>
+            <exclude>**/src/main/specs/**/*.js</exclude>
+            <exclude>**/src/main/specs/**/*.css</exclude>
             <exclude>**/src/main/javascript/modules/templates/**</exclude>
             <exclude>**/.git/**</exclude>
             <exclude>**/.gitignore</exclude>


### PR DESCRIPTION
It is a pain to see the license header at the top of the header in the sample gadgets.  So instead of having those headers I have removed them from the samples and added a note in the footer saying all sample gadgets and associates resources are covered under the apache v2 license.  This should be good enough.
