### PR TITLE
Remove declarative location menu

### DIFF
--- a/opensocial-explorer-webcontent/src/main/javascript/modules/templates/GadgetDropDownMenu.html
+++ b/opensocial-explorer-webcontent/src/main/javascript/modules/templates/GadgetDropDownMenu.html
@@ -1,11 +1,4 @@
 <ul class="dropdown-menu gadgetMenuDropDown" role="menu">
-	<li data-dojo-type="explorer/widgets/MenuItemWidget" data-dojo-attach-point="locationMenuItem" 
-	data-dojo-props="name : 'Location', class: 'dropdown-submenu pull-left'">
-		<ul class="dropdown-menu" role="menu">
-			<li data-dojo-type="explorer/widgets/MenuItemWidget" data-dojo-attach-point="sideMenuOption" data-dojo-props="name : 'Side'"></li>
-			<li data-dojo-type="explorer/widgets/MenuItemWidget" data-dojo-attach-point="bottomMenuOption" data-dojo-props="name : 'Bottom'"></li>
-		</ul>
-	</li>
 	<li data-dojo-type="explorer/widgets/MenuItemWidget" data-dojo-attach-point="preferencesMenuItem" data-dojo-props="name : 'Preferences'"></li>
 	<li data-dojo-type="explorer/widgets/MenuItemWidget" data-dojo-attach-point="viewsMenu" data-dojo-props="name : 'Views'"
 	data-dojo-props="name : 'Selection', class: 'dropdown-submenu pull-left'"></li>

--- a/opensocial-explorer-webcontent/src/main/javascript/modules/templates/LocationMenuItem.html
+++ b/opensocial-explorer-webcontent/src/main/javascript/modules/templates/LocationMenuItem.html
@@ -1,0 +1,7 @@
+<li class="dropdown-submenu pull-left">
+	<a tabindex="-1" href="javascript:void(0)">Location</a>
+	<ul class="dropdown-menu" role="menu">
+		<li data-dojo-type="explorer/widgets/MenuItemWidget" data-dojo-attach-point="sideMenuOption" data-dojo-props="name : 'Side'"></li>
+		<li data-dojo-type="explorer/widgets/MenuItemWidget" data-dojo-attach-point="bottomMenuOption" data-dojo-props="name : 'Bottom'"></li>
+	</ul>
+</li>

--- a/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/editorarea/EditorArea.js
+++ b/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/editorarea/EditorArea.js
@@ -80,7 +80,7 @@ define([ 'dojo/_base/declare', 'dijit/_WidgetBase', 'dijit/_TemplatedMixin', 'di
         });
       });
       
-      topic.subscribe("refreshEditors", function() {
+      this.refreshEditorsHandle = topic.subscribe("refreshEditors", function() {
         self.getEditorTabs().refreshEditors();
       });
     },
@@ -253,13 +253,13 @@ define([ 'dojo/_base/declare', 'dijit/_WidgetBase', 'dijit/_TemplatedMixin', 'di
     },
 
     /**
-     * Destroys this instance of EditorArea. For testing purposes.
+     * Destroys this instance of EditorArea.
      *
      * @memberof module:explorer/widgets/editorarea/EditorArea#
      */
     destroy : function() {
       this.inherited(arguments);
-      instance = undefined;
+      this.refreshEditorsHandle.remove();
     }
   });
 });

--- a/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/gadgetarea/GadgetArea.js
+++ b/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/gadgetarea/GadgetArea.js
@@ -29,9 +29,9 @@
 define(['dojo/_base/declare', 'dijit/_WidgetBase', 'dijit/_TemplatedMixin', 'dojo/topic',
         'dojo/_base/array', 'dojo/text!./../../templates/GadgetArea.html', './GadgetToolbar',
         'dojo/dom-construct','../Loading', '../../opensocial-data', './GadgetModalDialog',
-        'dojo/_base/window', 'dojo/dom', 'dojo/json', '../../ExplorerContainer', 'dojo/on'],
+        'dojo/_base/window', 'dojo/dom', 'dojo/json', '../../ExplorerContainer', 'dojo/on', './LocationMenuItem'],
         function(declare, WidgetBase, TemplatedMixin, topic, arrayUtil, template, GadgetToolbar, 
-            domConstruct, Loading, osData, GadgetModalDialog, win, dom, JSON, ExplorerContainer, on) {
+            domConstruct, Loading, osData, GadgetModalDialog, win, dom, JSON, ExplorerContainer, on, LocationMenuItem) {
       return declare('GadgetAreaWidget', [ WidgetBase, TemplatedMixin ], {
                 templateString : template,
                 containerToken : null,
@@ -50,6 +50,7 @@ define(['dojo/_base/declare', 'dijit/_WidgetBase', 'dijit/_TemplatedMixin', 'doj
       this.gadgetToolbar = new GadgetToolbar();
       domConstruct.place(this.gadgetToolbar.domNode, this.domNode);
       this.gadgetToolbar.startup();
+      this.addMenuItems();
       var self = this;
       this.gadgetToolbar.getPrefDialog().addPrefsChangedListener(function(prefs) {
         var params = {};
@@ -289,6 +290,18 @@ define(['dojo/_base/declare', 'dijit/_WidgetBase', 'dijit/_TemplatedMixin', 'doj
         this.getExplorerContainer().getContainer().closeGadget(this.site);
         domConstruct.destroy("gadgetSite" + this.siteCounter.toString());
       }
+    },
+    
+    /**
+     * Adds menu items to the gadget menu.  Sub-classes can override this method to
+     * add additional menus.
+     * 
+     * @memberof module:explorer/widgets/gadgetarea/GadgetArea#
+     */
+    addMenuItems: function() {
+      var locationMenuItem = new LocationMenuItem();
+      this.gadgetToolbar.addMenuItem(locationMenuItem);
+      locationMenuItem.startup();
     }
   });
 });

--- a/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/gadgetarea/GadgetDropDownMenu.js
+++ b/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/gadgetarea/GadgetDropDownMenu.js
@@ -31,8 +31,9 @@
 define(['dojo/_base/lang', 'dojo/_base/declare', '../DropDownMenu', 'dojo/Evented', 'dojo/topic',
         'dojo/query', 'dojo/dom-class', '../MenuItemWidget', '../../opensocial-data',
         'dojo/text!./../../templates/GadgetDropDownMenu.html', 'dijit/_WidgetsInTemplateMixin',
-        'dojo/on', 'dojo/NodeList-manipulate', 'dojo/NodeList-dom'],
-        function(lang, declare, DropDownMenu, Evented, topic, query, domClass, MenuItemWidget, osData, template, WidgetsInTemplateMixin, on) {
+        'dojo/on', 'dojo/dom-construct', 'dojo/NodeList-manipulate', 'dojo/NodeList-dom'],
+        function(lang, declare, DropDownMenu, Evented, topic, query, domClass, MenuItemWidget, osData, template, 
+                WidgetsInTemplateMixin, on, domConstruct) {
   return declare('GadgetDropDownMenuWidget', [ DropDownMenu, WidgetsInTemplateMixin, Evented ], {
     templateString : template,
 
@@ -52,18 +53,6 @@ define(['dojo/_base/lang', 'dojo/_base/declare', '../DropDownMenu', 'dojo/Evente
       });
       on(this.messageMenuOption.domNode,'click', function(e) {
         self.publishSelection('opensocial.Message');
-      });
-      on(this.sideMenuOption.domNode,'click', function(e) {
-        query('div.editor').removeClass('topBottom');
-        query('div.result').removeClass('topBottom');
-        query('.CodeMirror-scroll').removeClass('topBottom');
-        topic.publish("refreshEditors");
-      });
-      on(this.bottomMenuOption.domNode,'click', function(e) {
-        query('div.editor').addClass('topBottom');
-        query('div.result').addClass('topBottom');
-        query('.CodeMirror-scroll').addClass('topBottom');
-        topic.publish("refreshEditors");
       });
       on(this.preferencesMenuItem.domNode, 'click', function(e) {
         topic.publish('org.opensocial.explorer.prefdialog.show');
@@ -145,6 +134,16 @@ define(['dojo/_base/lang', 'dojo/_base/declare', '../DropDownMenu', 'dojo/Evente
       if(selection) {
         topic.publish("setSelection", selection);
       }
+    },
+    
+    /**
+     * Adds a menu item to the drop down menu.
+     * 
+     * @memberof module:explorer/widgets/gadgetarea/GadgetDropDownMenu#
+     * @param {module:explorer/widgets/MenuItemWidget} menuItem - The menu item to add.
+     */
+    addMenuItem : function(menuItem) {
+      domConstruct.place(menuItem.domNode, this.domNode, 'last');
     }
   });
 });

--- a/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/gadgetarea/GadgetToolbar.js
+++ b/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/gadgetarea/GadgetToolbar.js
@@ -95,6 +95,16 @@ define(['dojo/_base/declare', 'dijit/_WidgetBase', 'dijit/_TemplatedMixin',
      */
     removeAction : function(action) {
       this.gadgetMenuButton.getGadgetDropDownMenu().removeAction(action);
+    },
+    
+    /**
+     * Adds a menu item to the drop down menu.
+     * 
+     * @memberof module:explorer/widgets/gadgetarea/GadgetDropDownMenu#
+     * @param {module:explorer/widgets/MenuItemWidget} menuItem - The menu item to add.
+     */
+    addMenuItem : function(menuItem) {
+      this.gadgetMenuButton.getGadgetDropDownMenu().addMenuItem(menuItem);
     }
   });
 });

--- a/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/gadgetarea/LocationMenuItem.js
+++ b/opensocial-explorer-webcontent/src/main/javascript/modules/widgets/gadgetarea/LocationMenuItem.js
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The location menu.
+ *
+ * @module explorer/widgets/gadgetarea/LocationMenuItem
+ * @augments explorer/widgets/MenuItemWidget
+ * @augments dijit/_WidgetsInTemplateMixin
+ * @see {@link module:explorer/widgets/MenuItemWidget|MenuItemWidget Documentation}
+ * @see {@link http://dojotoolkit.org/reference-guide/1.8/dijit/_WidgetsInTemplateMixin.html|WidgetsInTemplateMixin Documentation}
+ */
+define(['dojo/_base/declare', '../MenuItemWidget', 'dijit/_WidgetsInTemplateMixin',
+        'dojo/text!./../../templates/LocationMenuItem.html',
+        'dojo/on', 'dojo/topic', 'dojo/query', 'dojo/NodeList-manipulate', 
+        'dojo/NodeList-dom'],
+        function(declare, MenuItemWidget, WidgetsInTemplateMixin, template, on, topic, query) {
+  return declare('LocationMenuItemWidget', [ MenuItemWidget, WidgetsInTemplateMixin ], {
+    templateString : template,
+
+    /**
+     * Called right after widget is added to the dom. See link for more information.
+     *
+     * @memberof module:explorer/widgets/gadgetarea/LocationMenuItem#
+     * @see {@link http://dojotoolkit.org/reference-guide/1.8/dijit/_WidgetBase.html|Dojo Documentation}
+     */
+    startup : function() {
+      var self = this;
+      on(this.sideMenuOption.domNode,'click', function(e) {
+        query('div.editor').removeClass('topBottom');
+        query('div.result').removeClass('topBottom');
+        query('.CodeMirror-scroll').removeClass('topBottom');
+        topic.publish("refreshEditors");
+      });
+      on(this.bottomMenuOption.domNode,'click', function(e) {
+        query('div.editor').addClass('topBottom');
+        query('div.result').addClass('topBottom');
+        query('.CodeMirror-scroll').addClass('topBottom');
+        topic.publish("refreshEditors");
+      });
+    },
+  });
+});

--- a/opensocial-explorer-webcontent/src/test/javascript/gadgetarea/LocationMenuItemTest.js
+++ b/opensocial-explorer-webcontent/src/test/javascript/gadgetarea/LocationMenuItemTest.js
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(['explorer/widgets/gadgetarea/LocationMenuItem', 'dojo/dom-construct',
+        'dojo/topic', 'dojo/dom-class'], function(LocationMenuItem, domConstruct, topic, domClass){
+  describe('A LocationMenuItem widget', function() {
+    
+    beforeEach(function() {      
+      var div = domConstruct.create('div', {id : "testDiv"});
+      editor = domConstruct.create('div', {id : "editor", class : "editor"});
+      result = domConstruct.create('div', {id : "result", class : "result"});
+      codeMirror = domConstruct.create('div', {id : "codeMirror", class : "CodeMirror-scroll"});
+      domConstruct.place(editor, div, 'last');
+      domConstruct.place(result, div, 'last');
+      domConstruct.place(codeMirror, div, 'last');
+      document.body.appendChild(div);
+      
+      locationMenu = new LocationMenuItem();
+      domConstruct.place(locationMenu.domNode, div, 'last');
+      locationMenu.startup();
+    });
+  
+    afterEach(function() {
+      locationMenu.destroy();
+      document.body.removeChild(document.getElementById('testDiv'));
+    });
+  
+    it("can move the result to the side", function() {
+      domClass.add(editor, 'topBottom');
+      domClass.add(result, 'topBottom');
+      domClass.add(codeMirror, 'topBottom');
+      var refreshed = false;
+      var handle = topic.subscribe("refreshEditors", function() {
+        refreshed = true;
+      });
+      runs(function() {
+        locationMenu.sideMenuOption.domNode.click();
+      });
+      
+      waitsFor(function() {
+        return refreshed;
+      }, "The refreshEditors topic was not published.", 750);
+      
+      runs(function() {
+        expect(domClass.contains(editor, 'topBottom')).toBeFalsy();
+        expect(domClass.contains(result, 'topBottom')).toBeFalsy();
+        expect(domClass.contains(codeMirror, 'topBottom')).toBeFalsy();
+        handle.remove();
+      });
+    });
+    
+    it("can move the result to the bottom", function() {
+      var refreshed = false;
+      var handle = topic.subscribe("refreshEditors", function() {
+        refreshed = true;
+      });
+      runs(function() {
+        locationMenu.bottomMenuOption.domNode.click();
+      });
+      
+      waitsFor(function() {
+        return refreshed;
+      }, "The refreshEditors topic was not published.", 750);
+      
+      runs(function() {
+        expect(domClass.contains(editor, 'topBottom')).toBeTruthy();
+        expect(domClass.contains(result, 'topBottom')).toBeTruthy();
+        expect(domClass.contains(codeMirror, 'topBottom')).toBeTruthy();
+        handle.remove();
+      });
+    });
+  });
+});

--- a/opensocial-explorer-webcontent/src/test/javascript/gadgetarea/LocationMenuItemTest.js
+++ b/opensocial-explorer-webcontent/src/test/javascript/gadgetarea/LocationMenuItemTest.js
@@ -49,7 +49,9 @@ define(['explorer/widgets/gadgetarea/LocationMenuItem', 'dojo/dom-construct',
         refreshed = true;
       });
       runs(function() {
-        locationMenu.sideMenuOption.domNode.click();
+        var event = document.createEvent("MouseEvents");
+        event.initEvent("click", true, true);
+        locationMenu.sideMenuOption.domNode.dispatchEvent(event);
       });
       
       waitsFor(function() {
@@ -70,7 +72,9 @@ define(['explorer/widgets/gadgetarea/LocationMenuItem', 'dojo/dom-construct',
         refreshed = true;
       });
       runs(function() {
-        locationMenu.bottomMenuOption.domNode.click();
+        var event = document.createEvent("MouseEvents");
+        event.initEvent("click", true, true);
+        locationMenu.bottomMenuOption.domNode.dispatchEvent(event);
       });
       
       waitsFor(function() {


### PR DESCRIPTION
If you reuse the gadget area dijit there may be some cases where a location menu does not make sense.  Instead of it being present in the template i have moved it to the code and added a way for subclasses to override a method so it does not get added.
